### PR TITLE
added padding to the heading of email and password 

### DIFF
--- a/login/login.css
+++ b/login/login.css
@@ -11,7 +11,7 @@ body {
   justify-content: center;
   align-items: center;
   height: 100vh;
-  background: url('/login/top-view-set-gadgets-purple-neon-light-pink.webp') no-repeat center center/cover;
+  background: url('/top-view-set-gadgets-purple-neon-light-pink.webp') no-repeat center center/cover;
   backdrop-filter: blur(10px);
 }
 
@@ -100,6 +100,7 @@ h2 {
   left: 10px;
   color: #ff69b4;
   font-size: 0.85rem;
+  padding-bottom:20px;
 }
 
 .remember {

--- a/login/login.css
+++ b/login/login.css
@@ -23,7 +23,7 @@ body {
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
   overflow: hidden;
   position: relative;
-  height: 520px;
+  height: 460px;
 }
 
 h2 {
@@ -62,8 +62,10 @@ h2 {
 
 .input-box {
   position: relative;
-  margin-bottom: 30px;
+  margin-bottom: 40px;
+  margin-top: 30px;
 }
+
 
 .input-box ion-icon {
   position: absolute;
@@ -107,6 +109,8 @@ h2 {
   color: #fff;
   display: flex;
   align-items: center;
+  /* margin-bottom: 70px; */
+  margin-top: -20px;
 }
 
 .btn {
@@ -118,6 +122,7 @@ h2 {
   border-radius: 8px;
   cursor: pointer;
   transition: background 0.3s ease;
+  margin-top:75px
 }
 
 .btn:hover {

--- a/login/login.html
+++ b/login/login.html
@@ -33,7 +33,7 @@
             <div class="input-box">
                 <ion-icon name="lock-closed-outline"></ion-icon>
                 <input type="password" required id="login-password">
-                <label>Password</label>
+                <label for="login-password">Password</label>
                 <button type="button" class="toggle-password" id="toggle-login-password">
                   <ion-icon name="eye-off-outline" id="eye-icon-login"></ion-icon>
                 </button>


### PR DESCRIPTION
i have corrected the padding on the email and password heading which comes in animation when we click on the input box of email and password
initially the website looked like this
<img width="1439" alt="Screenshot 2024-10-15 at 10 41 52 PM" src="https://github.com/user-attachments/assets/b16f0690-1354-4b82-befd-704df9514f18">
   and after i added the padding the headings looked like this as i have highlighted
<img width="1440" alt="Screenshot 2024-10-15 at 10 43 57 PM" src="https://github.com/user-attachments/assets/cdf7ea6d-77c4-4543-8e93-3efb0c800e5c">

@Abhilash107 please merge it if everything is alright
